### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,20 @@ on:
   push:
     branches: [main, alpha, beta, next]
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
@@ -35,4 +44,4 @@ jobs:
           git tag -f v${{steps.semantic.outputs.new_release_major_version}}
           git push -f https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git v${{steps.semantic.outputs.new_release_major_version}}
         env:
-          GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.